### PR TITLE
Add missing version pinning for xeokit-gltf-to-xkt

### DIFF
--- a/bin/preinstall
+++ b/bin/preinstall
@@ -45,8 +45,7 @@ if [ "$edition" = "bim" ]; then
 
 	if ! ${CLI} run which gltf2xkt &>/dev/null ; then
 		echo "Fetching and installing xeokit-gltf-to-xkt..."
-		# no NPM available at this time
-		${CLI} run npm install https://github.com/xeokit/xeokit-gltf-to-xkt/tarball/master
+		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@0.0.3
 	fi
 
 	if ! ${CLI} run which COLLADA2GLTF &>/dev/null ; then


### PR DESCRIPTION
The versions of xeokit-gltf-to-xkt unfortunately are messy. And the latest master is broken for us. I did some investigation and at some point they moved the npm package from `xeokit/xeokit-gltf-to-xkt` to `@xeokit/xeokit-gltf-to-xkt`. So they just added the `@`.