### PR TITLE
Bump gltf2xkt to version 1.0.0

### DIFF
--- a/bin/preinstall
+++ b/bin/preinstall
@@ -49,9 +49,9 @@ if [ "$edition" = "bim" ]; then
 
 	cd $tmpdir
 
-	if [ "$(${CLI} run gltf2xkt --version 2>&1)" != "1.0.0" ] ; then
+	if [ "$(${CLI} run gltf2xkt --version 2>&1)" != "1.1.1" ] ; then
 		echo "Fetching and installing xeokit-gltf-to-xkt..."
-		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@1.0.0
+		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@1.1.1
 	fi
 
 	if ! ${CLI} run which COLLADA2GLTF &>/dev/null ; then

--- a/bin/preinstall
+++ b/bin/preinstall
@@ -51,7 +51,7 @@ if [ "$edition" = "bim" ]; then
 
 	if ! ${CLI} run which gltf2xkt &>/dev/null ; then
 		echo "Fetching and installing xeokit-gltf-to-xkt..."
-		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@0.0.3
+		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@1.0.0
 	fi
 
 	if ! ${CLI} run which COLLADA2GLTF &>/dev/null ; then

--- a/bin/preinstall
+++ b/bin/preinstall
@@ -49,7 +49,7 @@ if [ "$edition" = "bim" ]; then
 
 	cd $tmpdir
 
-	if ! ${CLI} run which gltf2xkt &>/dev/null ; then
+	if [ "$(${CLI} run gltf2xkt --version 2>&1)" != "1.0.0" ] ; then
 		echo "Fetching and installing xeokit-gltf-to-xkt..."
 		${CLI} run npm install @xeokit/xeokit-gltf-to-xkt@1.0.0
 	fi


### PR DESCRIPTION
Hey @crohr,

I am preparing some Xeokit updates for 11.3. When updating to 11.3 we will need that new version of `xeokit-gltf-to-xkt`. How do we make sure, that this version jump will make into the release of 11.3 (and not before)?

Another question I have is regarding the `bin/preinstall` script. It seems to me that it only installs the necessary libs and packages if they are not installed yet. However, it doesn't check the version of each lib. Does it mean that on existing on-prem installations it would not do the update as intended by this PR here?

Thank you!